### PR TITLE
feat: Add configuration tab with keychain-based API key storage

### DIFF
--- a/SoraPlanner/ContentView.swift
+++ b/SoraPlanner/ContentView.swift
@@ -21,6 +21,11 @@ struct ContentView: View {
                 .tabItem {
                     Label("Library", systemImage: "video.stack")
                 }
+
+            ConfigurationView()
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
+                }
         }
         .frame(minWidth: 650, minHeight: 750)
         .environmentObject(playerCoordinator)

--- a/SoraPlanner/Services/KeychainService.swift
+++ b/SoraPlanner/Services/KeychainService.swift
@@ -1,0 +1,122 @@
+//
+//  KeychainService.swift
+//  SoraPlanner
+//
+//  Secure storage service for API keys using macOS Keychain Services.
+//
+
+import Foundation
+import Security
+import os.log
+
+/// Service for securely storing and retrieving sensitive data using macOS Keychain
+class KeychainService {
+    static let shared = KeychainService()
+
+    private let logger = SoraPlannerLoggers.keychain
+    private let service: String
+    private let account = "openai-api-key"
+
+    private init() {
+        // Use bundle identifier as service identifier
+        self.service = Bundle.main.bundleIdentifier ?? "com.soraplanner.app"
+    }
+
+    /// Saves the API key to the keychain
+    /// - Parameter key: The API key to store
+    /// - Throws: KeychainError if the save operation fails
+    func saveAPIKey(_ key: String) throws {
+        let keyData = key.data(using: .utf8)!
+
+        // First, try to delete any existing key
+        try? deleteAPIKey()
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: keyData,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+
+        guard status == errSecSuccess else {
+            logger.error("Failed to save API key to keychain: \(status)")
+            throw KeychainError.saveFailed(status: status)
+        }
+
+        logger.info("API key successfully saved to keychain")
+    }
+
+    /// Retrieves the API key from the keychain
+    /// - Returns: The stored API key, or nil if not found
+    func retrieveAPIKey() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess else {
+            if status != errSecItemNotFound {
+                logger.warning("Failed to retrieve API key from keychain: \(status)")
+            }
+            return nil
+        }
+
+        guard let data = result as? Data,
+              let key = String(data: data, encoding: .utf8) else {
+            logger.error("Failed to decode API key from keychain data")
+            return nil
+        }
+
+        logger.debug("API key successfully retrieved from keychain")
+        return key
+    }
+
+    /// Deletes the API key from the keychain
+    /// - Throws: KeychainError if the delete operation fails
+    func deleteAPIKey() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            logger.error("Failed to delete API key from keychain: \(status)")
+            throw KeychainError.deleteFailed(status: status)
+        }
+
+        logger.info("API key deleted from keychain")
+    }
+
+    /// Checks if an API key is currently stored in the keychain
+    /// - Returns: True if a key exists, false otherwise
+    func hasAPIKey() -> Bool {
+        return retrieveAPIKey() != nil
+    }
+}
+
+/// Errors that can occur during keychain operations
+enum KeychainError: LocalizedError {
+    case saveFailed(status: OSStatus)
+    case deleteFailed(status: OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .saveFailed(let status):
+            return "Failed to save API key to keychain (status: \(status))"
+        case .deleteFailed(let status):
+            return "Failed to delete API key from keychain (status: \(status))"
+        }
+    }
+}

--- a/SoraPlanner/Utilities/Logging.swift
+++ b/SoraPlanner/Utilities/Logging.swift
@@ -12,6 +12,7 @@ enum LogSubsystem: String {
     case ui = "ui"
     case video = "video"
     case networking = "networking"
+    case keychain = "keychain"
 
     var logger: Logger {
         Logger(subsystem: "com.yourorg.SoraPlanner", category: self.rawValue)
@@ -23,4 +24,5 @@ struct SoraPlannerLoggers {
     static let ui = LogSubsystem.ui.logger
     static let video = LogSubsystem.video.logger
     static let networking = LogSubsystem.networking.logger
+    static let keychain = LogSubsystem.keychain.logger
 }

--- a/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
+++ b/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
@@ -62,6 +62,24 @@ class VideoGenerationViewModel: ObservableObject {
 
     // MARK: - Public Methods
 
+    /// Retry initializing the API service (e.g., after user adds API key)
+    func retryAPIServiceInitialization() {
+        guard apiService == nil else {
+            // Already initialized
+            return
+        }
+
+        SoraPlannerLoggers.ui.info("Retrying API service initialization")
+        do {
+            self.apiService = try VideoAPIService()
+            self.errorMessage = nil
+            SoraPlannerLoggers.ui.info("API service initialization successful")
+        } catch {
+            SoraPlannerLoggers.ui.error("Failed to initialize API service: \(error.localizedDescription)")
+            self.errorMessage = error.localizedDescription
+        }
+    }
+
     /// Start video generation process
     func generateVideo() async {
         guard canGenerate else {

--- a/SoraPlanner/ViewModels/VideoLibraryViewModel.swift
+++ b/SoraPlanner/ViewModels/VideoLibraryViewModel.swift
@@ -32,6 +32,24 @@ class VideoLibraryViewModel: ObservableObject {
 
     // MARK: - Public Methods
 
+    /// Retry initializing the API service (e.g., after user adds API key)
+    func retryAPIServiceInitialization() {
+        guard apiService == nil else {
+            // Already initialized
+            return
+        }
+
+        SoraPlannerLoggers.ui.info("Retrying API service initialization")
+        do {
+            self.apiService = try VideoAPIService()
+            self.errorMessage = nil
+            SoraPlannerLoggers.ui.info("API service initialization successful")
+        } catch {
+            SoraPlannerLoggers.ui.error("Failed to initialize API service: \(error.localizedDescription)")
+            self.errorMessage = error.localizedDescription
+        }
+    }
+
     /// Load all videos from the API
     func loadVideos() async {
         SoraPlannerLoggers.ui.info("Loading video library")

--- a/SoraPlanner/Views/ConfigurationView.swift
+++ b/SoraPlanner/Views/ConfigurationView.swift
@@ -1,0 +1,223 @@
+//
+//  ConfigurationView.swift
+//  SoraPlanner
+//
+//  Configuration and settings interface for the application.
+//
+
+import SwiftUI
+import os.log
+
+struct ConfigurationView: View {
+    @State private var apiKey: String = ""
+    @State private var isKeyStored: Bool = false
+    @State private var showingSuccess: Bool = false
+    @State private var showingError: Bool = false
+    @State private var errorMessage: String = ""
+
+    private let logger = SoraPlannerLoggers.ui
+    private let keychainService = KeychainService.shared
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            VStack(spacing: 8) {
+                Image(systemName: "key.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.accentColor)
+                    .padding(.top, 40)
+
+                Text("API Configuration")
+                    .font(.title)
+                    .fontWeight(.semibold)
+
+                Text("Store your OpenAI API key securely in your macOS Keychain")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+            }
+            .padding(.bottom, 30)
+
+            // Configuration Form
+            VStack(alignment: .leading, spacing: 20) {
+                // Status Indicator
+                HStack {
+                    Image(systemName: isKeyStored ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundColor(isKeyStored ? .green : .orange)
+                    Text(isKeyStored ? "API Key Stored" : "No API Key Stored")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+                .padding(.horizontal)
+
+                // API Key Input
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("OpenAI API Key")
+                        .font(.headline)
+
+                    SecureField("sk-proj-...", text: $apiKey)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+
+                    HStack {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(.blue)
+                        Text("Get your API key from")
+                        Link("platform.openai.com", destination: URL(string: "https://platform.openai.com/api-keys")!)
+                    }
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+                .padding(.horizontal)
+
+                // Action Buttons
+                HStack(spacing: 12) {
+                    Button(action: saveAPIKey) {
+                        Label(isKeyStored ? "Update Key" : "Save Key", systemImage: "square.and.arrow.down")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    if isKeyStored {
+                        Button(role: .destructive, action: deleteAPIKey) {
+                            Label("Delete Key", systemImage: "trash")
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+                .padding(.horizontal)
+
+                // Success/Error Messages
+                if showingSuccess {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                        Text("API key saved successfully")
+                            .font(.subheadline)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.green.opacity(0.1))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                }
+
+                if showingError {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.red)
+                        Text(errorMessage)
+                            .font(.subheadline)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.red.opacity(0.1))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                }
+            }
+            .padding(.vertical)
+
+            Spacer()
+
+            // Footer Information
+            VStack(spacing: 12) {
+                Divider()
+
+                VStack(spacing: 8) {
+                    HStack {
+                        Image(systemName: "lock.shield.fill")
+                            .foregroundColor(.green)
+                        Text("Your API key is encrypted and stored securely in macOS Keychain")
+                    }
+
+                    HStack {
+                        Image(systemName: "eye.slash.fill")
+                            .foregroundColor(.blue)
+                        Text("Keys are never logged or transmitted anywhere except to OpenAI")
+                    }
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.horizontal)
+                .padding(.bottom, 20)
+            }
+        }
+        .frame(maxWidth: 600)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            checkStoredKey()
+        }
+    }
+
+    // MARK: - Actions
+
+    private func checkStoredKey() {
+        isKeyStored = keychainService.hasAPIKey()
+        logger.debug("Checked keychain - API key stored: \(self.isKeyStored)")
+    }
+
+    private func saveAPIKey() {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedKey.isEmpty else {
+            showError("API key cannot be empty")
+            return
+        }
+
+        do {
+            try keychainService.saveAPIKey(trimmedKey)
+            logger.info("API key saved successfully")
+
+            // Clear input and update UI
+            apiKey = ""
+            isKeyStored = true
+            showSuccess()
+        } catch {
+            logger.error("Failed to save API key: \(error.localizedDescription)")
+            showError("Failed to save API key: \(error.localizedDescription)")
+        }
+    }
+
+    private func deleteAPIKey() {
+        do {
+            try keychainService.deleteAPIKey()
+            logger.info("API key deleted successfully")
+
+            // Update UI
+            apiKey = ""
+            isKeyStored = false
+            showSuccess()
+        } catch {
+            logger.error("Failed to delete API key: \(error.localizedDescription)")
+            showError("Failed to delete API key: \(error.localizedDescription)")
+        }
+    }
+
+    private func showSuccess() {
+        showingSuccess = true
+        showingError = false
+
+        // Auto-hide after 3 seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            showingSuccess = false
+        }
+    }
+
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
+        showingSuccess = false
+
+        // Auto-hide after 5 seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            showingError = false
+        }
+    }
+}
+
+#Preview {
+    ConfigurationView()
+}

--- a/SoraPlanner/Views/VideoGenerationView.swift
+++ b/SoraPlanner/Views/VideoGenerationView.swift
@@ -182,6 +182,10 @@ struct VideoGenerationView: View {
             }
         }
         .frame(minWidth: 600, minHeight: 700)
+        .onAppear {
+            // Retry API service initialization in case user just added API key in Settings
+            viewModel.retryAPIServiceInitialization()
+        }
     }
 }
 

--- a/SoraPlanner/Views/VideoLibraryView.swift
+++ b/SoraPlanner/Views/VideoLibraryView.swift
@@ -97,6 +97,8 @@ struct VideoLibraryView: View {
         }
         .frame(minWidth: 600, minHeight: 700)
         .task {
+            // Retry API service initialization in case user just added API key in Settings
+            viewModel.retryAPIServiceInitialization()
             await viewModel.loadVideos()
         }
     }


### PR DESCRIPTION
## Summary

Implements secure API key storage using macOS Keychain Services with a dedicated Settings tab, replacing the environment variable-only approach with a more user-friendly and secure solution.

**Closes #3**

## What Changed

### New Files
- **KeychainService.swift** - Secure storage service using macOS Keychain Services
  - Save/retrieve/delete API key operations
  - `.whenUnlocked` accessibility level for security
  - Comprehensive error handling with typed errors
  
- **ConfigurationView.swift** - Settings tab UI
  - Password-style masked input field (SecureField)
  - Visual status indicators for key storage state
  - Save, update, and delete functionality
  - User-friendly error and success messages
  - Direct link to OpenAI API key page

### Modified Files
- **VideoAPIService.swift** - Updated initialization logic
  - Checks keychain first (preferred method)
  - Falls back to environment variable (backward compatibility)
  - Updated error message to guide users to Settings tab
  
- **ContentView.swift** - Added Settings tab to TabView
  - New third tab with gear icon
  
- **Logging.swift** - Added keychain logging subsystem
  - New `keychain` category for security-related events
  
- **CLAUDE.md** - Updated documentation
  - Added Configuration & Settings section to Core Features
  - Updated API Key Configuration with keychain-first approach
  - Added Security section with keychain implementation details
  - Updated project structure and architecture patterns

## Security Features

✅ API keys encrypted by macOS Keychain Services  
✅ `.whenUnlocked` accessibility - keys only accessible when device unlocked  
✅ Password-style masking in UI prevents shoulder-surfing  
✅ Keys never logged or exposed in debug output  
✅ Uses app bundle identifier for service isolation  

## Backward Compatibility

The implementation maintains full backward compatibility:
- Environment variable `OPENAI_API_KEY` still works
- Keychain storage takes precedence if both are configured
- Existing users with environment variable set will continue to work
- Clear migration path: users can save key in Settings tab

## Testing

✅ Project builds successfully with no errors  
✅ All new code follows existing architecture patterns  
✅ Logging integrated with unified logging system  

## Screenshots

The new Settings tab provides:
- Clear API key status indicator
- Secure password-style input
- Save/Update/Delete buttons
- Link to OpenAI API key page
- Success/error feedback messages
- Security reassurance messaging

## User Experience Improvements

- **More intuitive**: Native macOS settings experience
- **No restart required**: API key changes take effect immediately on next API call
- **Persistent**: Key survives app restarts
- **Discoverable**: Settings tab visible in main interface
- **Helpful**: Clear error messages guide users to Settings tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)