### PR TITLE
feat: Add delete button to video library items

### DIFF
--- a/SoraPlanner/ViewModels/VideoLibraryViewModel.swift
+++ b/SoraPlanner/ViewModels/VideoLibraryViewModel.swift
@@ -79,6 +79,27 @@ class VideoLibraryViewModel: ObservableObject {
         await loadVideos()
     }
 
+    /// Delete a video from the library
+    func deleteVideo(_ video: VideoJob) async {
+        guard let service = apiService else {
+            SoraPlannerLoggers.ui.error("Cannot delete video - API service not available")
+            errorMessage = "API service not available"
+            return
+        }
+
+        SoraPlannerLoggers.ui.info("Deleting video: \(video.id)")
+
+        do {
+            try await service.deleteVideo(videoId: video.id)
+            // Remove from local list
+            videos.removeAll { $0.id == video.id }
+            SoraPlannerLoggers.ui.info("Video deleted from library: \(video.id)")
+        } catch {
+            SoraPlannerLoggers.ui.error("Failed to delete video: \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
     // MARK: - Helper Methods
 
     /// Get a user-friendly status description

--- a/SoraPlanner/Views/VideoLibraryView.swift
+++ b/SoraPlanner/Views/VideoLibraryView.swift
@@ -107,6 +107,7 @@ struct VideoLibraryView: View {
 struct VideoLibraryRow: View {
     let video: VideoJob
     @ObservedObject var viewModel: VideoLibraryViewModel
+    @State private var showDeleteConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -123,6 +124,16 @@ struct VideoLibraryRow: View {
                 }
 
                 Spacer()
+
+                // Delete Button
+                Button(action: {
+                    showDeleteConfirmation = true
+                }) {
+                    Image(systemName: "trash")
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+                .help("Delete video")
 
                 // Video ID
                 Text("ID: \(video.id)")
@@ -207,6 +218,20 @@ struct VideoLibraryRow: View {
                 .stroke(video.status == .completed ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 2)
         )
         .help(video.status == .completed ? "Tap to play video" : "Video not ready for playback")
+        .confirmationDialog(
+            "Delete Video?",
+            isPresented: $showDeleteConfirmation,
+            presenting: video
+        ) { video in
+            Button("Delete", role: .destructive) {
+                Task {
+                    await viewModel.deleteVideo(video)
+                }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: { video in
+            Text("Are you sure you want to delete video \(video.id)? This action cannot be undone.")
+        }
     }
 
     private var statusColor: Color {


### PR DESCRIPTION
## Summary

This PR implements delete functionality for video library items, allowing users to remove videos from their library. Each video item now has a delete button that calls the OpenAI Video API's delete endpoint.

## Changes

- **VideoAPIService.swift**: Added `deleteVideo(videoId:)` method to call `DELETE /v1/videos/{video_id}` API endpoint
- **VideoLibraryViewModel.swift**: Added `deleteVideo(_:)` method to handle video deletion and update local state
- **VideoLibraryView.swift**: Added delete button with confirmation dialog to `VideoLibraryRow`

## Features

- ✅ Delete button appears on each video item (red trash icon)
- ✅ Confirmation dialog prevents accidental deletions
- ✅ Successfully deleted videos are removed from the local list immediately
- ✅ Proper error handling with logging (api and ui subsystems)
- ✅ Works for all video statuses (queued, in-progress, completed, failed)
- ✅ Button styling prevents interference with row tap gesture for playback

## Technical Details

- Follows existing service patterns and error handling conventions
- Uses `VideoAPIError` enum for typed errors
- Maintains @MainActor isolation for thread safety
- Includes comprehensive logging for delete operations
- UI uses `.buttonStyle(.plain)` to avoid capturing row tap events

## Testing

- ✅ Project builds without errors
- Ready for manual testing with actual API

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)