### PR TITLE
refactor: Simplify video generation flow to reset after kickoff

### DIFF
--- a/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
+++ b/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
@@ -15,36 +15,14 @@ class VideoGenerationViewModel: ObservableObject {
     // MARK: - Published Properties
     @Published var prompt: String = ""
     @Published var duration: Int = 4 // Duration in seconds (default 4)
-    @Published var currentVideoJob: VideoJob?
-    @Published var videoURL: URL?
     @Published var isGenerating: Bool = false
     @Published var errorMessage: String?
+    @Published var successMessage: String?
 
     // MARK: - Private Properties
     private var apiService: VideoAPIService?
-    nonisolated(unsafe) private var pollingTask: Task<Void, Never>?
 
     // MARK: - Computed Properties
-    var statusMessage: String {
-        guard let job = currentVideoJob else {
-            return "Ready to generate"
-        }
-
-        switch job.status {
-        case .queued:
-            return "Queued for generation..."
-        case .inProgress:
-            if let progress = job.progress {
-                return "Processing: \(progress)%"
-            }
-            return "Processing..."
-        case .completed:
-            return "Generation complete!"
-        case .failed:
-            return "Generation failed"
-        }
-    }
-
     var canGenerate: Bool {
         !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isGenerating
     }
@@ -91,8 +69,7 @@ class VideoGenerationViewModel: ObservableObject {
 
         isGenerating = true
         errorMessage = nil
-        videoURL = nil
-        currentVideoJob = nil
+        successMessage = nil
 
         do {
             guard let service = apiService else {
@@ -101,12 +78,20 @@ class VideoGenerationViewModel: ObservableObject {
 
             // Create video job
             let job = try await service.createVideo(prompt: prompt, seconds: String(duration))
-            currentVideoJob = job
 
             SoraPlannerLoggers.ui.info("Video job created: \(job.id)")
 
-            // Start polling for status updates
-            startPolling()
+            // Show success message
+            successMessage = "Video queued! Check the Library tab for status."
+
+            // Reset form after brief delay
+            try await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 seconds
+
+            // Reset the form
+            prompt = ""
+            duration = 4
+            successMessage = nil
+            isGenerating = false
 
         } catch {
             SoraPlannerLoggers.ui.error("Failed to create video job: \(error.localizedDescription)")
@@ -115,102 +100,8 @@ class VideoGenerationViewModel: ObservableObject {
         }
     }
 
-    /// Cancel ongoing generation
-    func cancelGeneration() {
-        SoraPlannerLoggers.ui.info("Cancelling video generation")
-        stopPolling()
-        isGenerating = false
-        currentVideoJob = nil
-        errorMessage = nil
-    }
-
-    // MARK: - Private Methods
-
-    /// Start polling for video status updates
-    private func startPolling() {
-        guard let videoId = currentVideoJob?.id else {
-            SoraPlannerLoggers.ui.error("Cannot poll: no video ID")
-            return
-        }
-
-        SoraPlannerLoggers.ui.info("Starting status polling for video: \(videoId)")
-
-        pollingTask = Task {
-            while !Task.isCancelled {
-                do {
-                    guard let service = apiService else {
-                        throw VideoAPIError.missingAPIKey
-                    }
-
-                    // Poll for status
-                    let updatedJob = try await service.getVideoStatus(videoId: videoId)
-                    currentVideoJob = updatedJob
-
-                    // Handle status changes
-                    switch updatedJob.status {
-                    case .completed:
-                        SoraPlannerLoggers.ui.info("Video generation completed")
-                        await handleVideoCompleted(videoId: videoId)
-                        return
-
-                    case .failed:
-                        SoraPlannerLoggers.ui.error("Video generation failed: \(updatedJob.error?.message ?? "Unknown error")")
-                        errorMessage = updatedJob.error?.message ?? "Video generation failed"
-                        isGenerating = false
-                        return
-
-                    case .queued, .inProgress:
-                        // Continue polling
-                        SoraPlannerLoggers.ui.debug("Video status: \(updatedJob.status.rawValue)")
-                    }
-
-                    // Wait 2 seconds before next poll
-                    try await Task.sleep(nanoseconds: 2_000_000_000)
-
-                } catch is CancellationError {
-                    SoraPlannerLoggers.ui.info("Polling cancelled")
-                    return
-                } catch {
-                    SoraPlannerLoggers.ui.error("Polling error: \(error.localizedDescription)")
-                    errorMessage = error.localizedDescription
-                    isGenerating = false
-                    return
-                }
-            }
-        }
-    }
-
-    /// Stop polling for status updates
-    nonisolated private func stopPolling() {
-        pollingTask?.cancel()
-        pollingTask = nil
-        SoraPlannerLoggers.ui.info("Status polling stopped")
-    }
-
-    /// Handle video completion - download and prepare for playback
-    private func handleVideoCompleted(videoId: String) async {
-        do {
-            guard let service = apiService else {
-                throw VideoAPIError.missingAPIKey
-            }
-
-            SoraPlannerLoggers.video.info("Downloading completed video: \(videoId)")
-            let localURL = try await service.downloadVideo(videoId: videoId)
-            videoURL = localURL
-            isGenerating = false
-
-            SoraPlannerLoggers.video.info("Video ready for playback: \(localURL.path)")
-
-        } catch {
-            SoraPlannerLoggers.video.error("Failed to download video: \(error.localizedDescription)")
-            errorMessage = "Failed to download video: \(error.localizedDescription)"
-            isGenerating = false
-        }
-    }
-
     // MARK: - Cleanup
-    deinit {
-        stopPolling()
-        SoraPlannerLoggers.ui.info("VideoGenerationViewModel deinitialized")
+    nonisolated deinit {
+        print("VideoGenerationViewModel deinitialized")
     }
 }

--- a/SoraPlanner/Views/VideoGenerationView.swift
+++ b/SoraPlanner/Views/VideoGenerationView.swift
@@ -86,7 +86,7 @@ struct VideoGenerationView: View {
                             .scaleEffect(0.8)
                             .padding(.trailing, 4)
                     }
-                    Text(viewModel.isGenerating ? "Generating..." : "Generate Video")
+                    Text(viewModel.isGenerating ? "Submitting..." : "Generate Video")
                 }
                 .frame(maxWidth: .infinity)
                 .padding()
@@ -97,35 +97,18 @@ struct VideoGenerationView: View {
             .disabled(!viewModel.canGenerate)
             .padding(.horizontal)
 
-            // Status Section
-            if viewModel.isGenerating || viewModel.currentVideoJob != nil {
-                VStack(spacing: 12) {
-                    // Animated Progress Indicator
-                    if viewModel.isGenerating {
-                        Image(systemName: "arrow.triangle.2.circlepath.circle.fill")
-                            .font(.system(size: 40))
-                            .foregroundColor(.accentColor)
-                            .symbolEffect(.rotate, options: .repeating)
-                    }
-
-                    // Status Message
-                    Text(viewModel.statusMessage)
-                        .font(.headline)
-                        .foregroundColor(.secondary)
-
-                    // Progress Bar (if available)
-                    if let job = viewModel.currentVideoJob,
-                       let progress = job.progress {
-                        ProgressView(value: Double(progress), total: 100.0)
-                            .frame(maxWidth: 300)
-                        Text("\(progress)%")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
+            // Success Message
+            if let successMessage = viewModel.successMessage {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                    Text(successMessage)
+                        .font(.caption)
+                        .foregroundColor(.green)
                 }
                 .padding()
-                .background(Color(NSColor.controlBackgroundColor))
-                .cornerRadius(12)
+                .background(Color.green.opacity(0.1))
+                .cornerRadius(8)
                 .padding(.horizontal)
             }
 
@@ -144,42 +127,7 @@ struct VideoGenerationView: View {
                 .padding(.horizontal)
             }
 
-            // Video Ready - Show Play Button
-            if let job = viewModel.currentVideoJob, job.status == .completed {
-                VStack(spacing: 12) {
-                    Text("Video Ready!")
-                        .font(.headline)
-                        .foregroundColor(.green)
-
-                    Button(action: {
-                        Task {
-                            await playerCoordinator.play(job)
-                        }
-                    }) {
-                        HStack {
-                            Image(systemName: "play.circle.fill")
-                            Text("Play Video")
-                        }
-                        .font(.title3)
-                        .padding()
-                        .background(Color.accentColor)
-                        .foregroundColor(.white)
-                        .cornerRadius(10)
-                    }
-                }
-                .padding()
-            }
-
             Spacer()
-
-            // Cancel Button (shown during generation)
-            if viewModel.isGenerating {
-                Button("Cancel Generation") {
-                    viewModel.cancelGeneration()
-                }
-                .foregroundColor(.red)
-                .padding(.bottom)
-            }
         }
         .frame(minWidth: 600, minHeight: 700)
         .onAppear {


### PR DESCRIPTION
## Summary

Simplifies the video generation flow by removing polling from the generation tab. After a user taps Generate, the video is queued and the form resets automatically, allowing users to quickly queue multiple videos. Status tracking is now exclusively handled in the Library tab.

## Changes

**VideoGenerationViewModel.swift**
- Removed polling logic and Task management
- Removed `currentVideoJob`, `videoURL`, and `pollingTask` properties
- Added `successMessage` property for user feedback
- Simplified `generateVideo()` to:
  1. Submit video to API
  2. Show success message
  3. Reset form after 1.5 seconds
- Removed `cancelGeneration()`, `startPolling()`, `stopPolling()`, and `handleVideoCompleted()` methods

**VideoGenerationView.swift**
- Removed status display, progress indicators, and video player
- Added success message display (green banner)
- Changed button text from "Generating..." to "Submitting..."
- Removed cancel button and video ready section
- Simplified UI to focus on prompt input and queueing

## User Experience Flow

**Before:** 
1. Enter prompt → Generate → Wait on generation tab → Watch progress → Play video
2. Could only generate one video at a time

**After:**
1. Enter prompt → Generate → See "Video queued!" message → Form resets
2. Can immediately queue another video
3. Check Library tab for status and playback

## Benefits

- **Faster workflow**: Users can queue multiple videos without waiting
- **Cleaner separation**: Generation tab for input, Library tab for tracking
- **Simpler code**: Removed ~120 lines of polling and state management
- **Better UX**: Clear feedback that video is queued, then ready for next generation

## Technical Notes

- Success message shows for 1.5 seconds before form reset
- All video status tracking happens in Library tab's existing polling logic
- No breaking changes to API service layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)