### PR TITLE
feat: Enhance error display in video library with error code

### DIFF
--- a/SoraPlanner/Views/VideoLibraryView.swift
+++ b/SoraPlanner/Views/VideoLibraryView.swift
@@ -185,12 +185,19 @@ struct VideoLibraryRow: View {
 
             // Error Message (if failed)
             if video.status == .failed, let error = video.error {
-                HStack(spacing: 4) {
-                    Image(systemName: "exclamationmark.circle.fill")
-                        .foregroundColor(.red)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "exclamationmark.circle.fill")
+                            .foregroundColor(.red)
+                        Text("Error: \(error.code)")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.red)
+                    }
                     Text(error.message)
-                        .font(.caption)
-                        .foregroundColor(.red)
+                        .font(.caption2)
+                        .foregroundColor(.red.opacity(0.9))
+                        .lineLimit(3)
                 }
                 .padding(.top, 4)
             }


### PR DESCRIPTION
## Summary

Enhances the error display for failed videos in the library to show both the error code and message, providing users with more detailed information about why a video generation failed.

## Changes

**VideoLibraryView.swift**
- Changed error display from single line to VStack layout
- Added error code display with "Error:" prefix in bold
- Show error message on separate line below the code
- Added line limit (3 lines) for long error messages
- Use slightly transparent text for message to create visual hierarchy

## Visual Improvements

**Before:**
```
🔴 Content policy violation
```

**After:**
```
🔴 Error: content_policy_violation
   Content policy violation
```

## Technical Details

The `VideoError` model already contains both `code` and `message` fields from the API. This change displays both pieces of information:
- **Error code**: Technical identifier (e.g., `content_policy_violation`, `rate_limit_exceeded`)
- **Error message**: Human-readable description

## Benefits

- **Better debugging**: Error codes help identify specific failure types
- **Clearer context**: Users understand both what went wrong (code) and why (message)
- **Professional UX**: Structured error display similar to other developer tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)