### PR TITLE
feat: Add Prompts tab with persistent prompt library and modal generation UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,33 @@ SoraPlanner is a macOS application for planning and managing video generations u
 
 ## Project Overview
 
-This application provides a native macOS interface for creating, tracking, and managing AI-generated videos through OpenAI's video generation platform. It features a tabbed interface with separate views for video generation and library management, integrated video playback, and real-time status polling for generation jobs.
+This application provides a native macOS interface for creating, tracking, and managing AI-generated videos through OpenAI's video generation platform. It features a tabbed interface with dedicated views for prompt library management, video library, and settings. The app includes persistent prompt storage, modal video generation, integrated video playback, and real-time status polling for generation jobs.
 
 ## Core Features
 
-### Video Generation Interface
+### Prompt Library Management
+- Dedicated Prompts tab with persistent storage of reusable video prompts
+- Inline editing of prompt title and text (max 2000 characters)
+- Character count indicator with visual feedback
+- Modal video generation workflow from prompts or empty state
+- Auto-save functionality on prompt changes
+- Individual Generate buttons per prompt for quick access
+- Toolbar Generate button for creating videos with empty prompts
+- Add new prompt functionality via toolbar button
+- Delete prompt with confirmation dialog
+- Created and modified timestamps for each prompt
+- Prompts persisted using UserDefaults (survives app restarts)
+
+### Video Generation Interface (Modal)
+- Modal presentation launched from Prompt Library
 - Interactive prompt editor with multi-line text support
-- Duration selection (4, 10, or 30 seconds) with pricing information
+- Optional pre-filled prompt from library or empty state
+- Duration selection (4, 8, or 12 seconds) with pricing information
 - Real-time generation status monitoring with progress indicators
 - Animated visual feedback during video processing
 - Integrated error handling and user-friendly error messages
-- Automatic status polling for queued and in-progress jobs
-- Direct playback of completed videos
+- Auto-dismiss after successful video generation
+- Success message display before dismissal
 
 ### Video Library Management
 - Comprehensive list view of all generated videos
@@ -57,6 +72,7 @@ This application provides a native macOS interface for creating, tracking, and m
 - **Logging**: Apple's Unified Logging System (os.log)
 - **Networking**: URLSession with async/await
 - **Security**: macOS Keychain Services for secure credential storage
+- **Persistence**: UserDefaults for prompt library storage
 
 ## API Integration
 
@@ -80,18 +96,21 @@ The application integrates with OpenAI's Video API through a dedicated service l
 ```
 SoraPlanner/
 ├── SoraPlannerApp.swift           # Main app entry point
-├── ContentView.swift               # Root view with tab navigation and player coordinator
+├── ContentView.swift               # Root view with tab navigation, modal sheets, and player coordinator
 ├── Models/
+│   ├── Prompt.swift               # Prompt data model for library (Identifiable, Codable)
 │   └── VideoJob.swift             # Core data models (VideoJob, VideoStatus, VideoError)
 ├── Services/
 │   ├── VideoAPIService.swift      # OpenAI Video API client
 │   └── KeychainService.swift      # Secure keychain storage service
 ├── ViewModels/
+│   ├── PromptLibraryViewModel.swift     # Business logic for prompt library with persistence
 │   ├── VideoGenerationViewModel.swift   # Business logic for video generation
 │   ├── VideoLibraryViewModel.swift      # Business logic for video library
 │   └── VideoPlayerCoordinator.swift     # Shared video playback coordinator
 ├── Views/
-│   ├── VideoGenerationView.swift      # Video creation interface
+│   ├── PromptLibraryView.swift        # Prompt library tab with inline editing
+│   ├── VideoGenerationView.swift      # Video creation modal interface
 │   ├── VideoLibraryView.swift         # Video list and management interface
 │   ├── VideoPlayerView.swift          # Video playback modal with metadata display
 │   ├── LoopingVideoPlayerView.swift   # Custom looping player using AVPlayerLooper
@@ -109,9 +128,16 @@ internal_docs/                     # API documentation and reference materials
 ## Architecture Patterns
 
 ### MVVM (Model-View-ViewModel)
-- **Models**: Codable structs for API request/response (VideoJob, CreateVideoRequest, etc.)
+- **Models**: Codable structs for API request/response (VideoJob, CreateVideoRequest, etc.) and local data (Prompt)
 - **ViewModels**: Observable objects managing business logic and state (@MainActor isolated)
 - **Views**: SwiftUI views with declarative UI and data binding
+
+### Prompt Library Persistence
+- `PromptLibraryViewModel` manages prompt CRUD operations with UserDefaults persistence
+- Prompts stored as JSON-encoded array using `UserDefaults.standard`
+- Auto-save on all modifications (add, update, delete)
+- Automatic loading on app launch
+- Storage key: `saved_prompts`
 
 ### Coordinator Pattern
 - `VideoPlayerCoordinator` manages shared video playback state across tabs
@@ -224,16 +250,21 @@ The application checks keychain first, then falls back to environment variable. 
 - Videos are downloaded to temporary directory (not persisted between app launches)
 - No local video storage or caching mechanism
 - Polling interval fixed at 2 seconds (not configurable)
-- No support for video deletion via UI (API endpoint available but not implemented)
 - No support for video remixing features (API supports but not yet implemented)
+- Prompts stored in UserDefaults (lightweight, but no iCloud sync or backup)
 
 ## Future Enhancement Opportunities
 
 - Persistent local video storage with cache management
 - Configurable polling intervals
-- Delete video functionality in library view
-- Video prompt history and favorites
-- Batch video generation
+- Batch video generation from multiple prompts
 - Video remixing from existing videos
-- Advanced filtering and sorting in library
+- Advanced filtering and sorting in video library
 - Export video with metadata
+- Prompt templates and categories
+- Search/filter functionality for prompts
+- Import/export prompts as JSON
+- Prompt sharing between devices via iCloud
+- Tags or folders for prompt organization
+- Duplicate prompt functionality
+- Drag-to-reorder prompts

--- a/SoraPlanner/ContentView.swift
+++ b/SoraPlanner/ContentView.swift
@@ -7,22 +7,25 @@
 
 import SwiftUI
 
+// Identifiable wrapper for sheet presentation with proper view identity
+struct VideoGenerationRequest: Identifiable {
+    let id = UUID()
+    let initialPrompt: String?
+}
+
 struct ContentView: View {
     @StateObject private var playerCoordinator = VideoPlayerCoordinator()
-    @State private var showGenerationModal = false
-    @State private var promptToGenerate: String?
+    @State private var generationRequest: VideoGenerationRequest?
     @State private var showGenerationSuccess = false
 
     var body: some View {
         TabView {
             PromptLibraryView(
                 onGeneratePrompt: { prompt in
-                    promptToGenerate = prompt
-                    showGenerationModal = true
+                    generationRequest = VideoGenerationRequest(initialPrompt: prompt)
                 },
                 onGenerateEmpty: {
-                    promptToGenerate = nil
-                    showGenerationModal = true
+                    generationRequest = VideoGenerationRequest(initialPrompt: nil)
                 }
             )
             .tabItem {
@@ -45,12 +48,9 @@ struct ContentView: View {
             VideoPlayerView(video: video)
                 .environmentObject(playerCoordinator)
         }
-        .sheet(isPresented: $showGenerationModal, onDismiss: {
-            // Reset prompt when modal is dismissed
-            promptToGenerate = nil
-        }) {
+        .sheet(item: $generationRequest) { request in
             VideoGenerationView(
-                initialPrompt: promptToGenerate,
+                initialPrompt: request.initialPrompt,
                 onGenerationSuccess: {
                     showGenerationSuccess = true
                 }

--- a/SoraPlanner/ContentView.swift
+++ b/SoraPlanner/ContentView.swift
@@ -17,12 +17,10 @@ struct ContentView: View {
         TabView {
             PromptLibraryView(
                 onGeneratePrompt: { prompt in
-                    print("DEBUG: Setting promptToGenerate to: '\(prompt)'")
                     promptToGenerate = prompt
                     showGenerationModal = true
                 },
                 onGenerateEmpty: {
-                    print("DEBUG: Setting promptToGenerate to nil")
                     promptToGenerate = nil
                     showGenerationModal = true
                 }

--- a/SoraPlanner/ContentView.swift
+++ b/SoraPlanner/ContentView.swift
@@ -9,13 +9,24 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var playerCoordinator = VideoPlayerCoordinator()
+    @State private var showGenerationModal = false
+    @State private var promptToGenerate: String?
 
     var body: some View {
         TabView {
-            VideoGenerationView()
-                .tabItem {
-                    Label("Generate", systemImage: "wand.and.stars")
+            PromptLibraryView(
+                onGeneratePrompt: { prompt in
+                    promptToGenerate = prompt
+                    showGenerationModal = true
+                },
+                onGenerateEmpty: {
+                    promptToGenerate = nil
+                    showGenerationModal = true
                 }
+            )
+            .tabItem {
+                Label("Prompts", systemImage: "doc.text.fill")
+            }
 
             VideoLibraryView()
                 .tabItem {
@@ -31,6 +42,13 @@ struct ContentView: View {
         .environmentObject(playerCoordinator)
         .sheet(item: $playerCoordinator.currentVideo) { video in
             VideoPlayerView(video: video)
+                .environmentObject(playerCoordinator)
+        }
+        .sheet(isPresented: $showGenerationModal, onDismiss: {
+            // Reset prompt when modal is dismissed
+            promptToGenerate = nil
+        }) {
+            VideoGenerationView(initialPrompt: promptToGenerate)
                 .environmentObject(playerCoordinator)
         }
     }

--- a/SoraPlanner/ContentView.swift
+++ b/SoraPlanner/ContentView.swift
@@ -11,15 +11,18 @@ struct ContentView: View {
     @StateObject private var playerCoordinator = VideoPlayerCoordinator()
     @State private var showGenerationModal = false
     @State private var promptToGenerate: String?
+    @State private var showGenerationSuccess = false
 
     var body: some View {
         TabView {
             PromptLibraryView(
                 onGeneratePrompt: { prompt in
+                    print("DEBUG: Setting promptToGenerate to: '\(prompt)'")
                     promptToGenerate = prompt
                     showGenerationModal = true
                 },
                 onGenerateEmpty: {
+                    print("DEBUG: Setting promptToGenerate to nil")
                     promptToGenerate = nil
                     showGenerationModal = true
                 }
@@ -48,8 +51,18 @@ struct ContentView: View {
             // Reset prompt when modal is dismissed
             promptToGenerate = nil
         }) {
-            VideoGenerationView(initialPrompt: promptToGenerate)
-                .environmentObject(playerCoordinator)
+            VideoGenerationView(
+                initialPrompt: promptToGenerate,
+                onGenerationSuccess: {
+                    showGenerationSuccess = true
+                }
+            )
+            .environmentObject(playerCoordinator)
+        }
+        .alert("Generation Queued", isPresented: $showGenerationSuccess) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Your video has been queued for generation. Check the Library tab to monitor its progress.")
         }
     }
 }

--- a/SoraPlanner/Models/Prompt.swift
+++ b/SoraPlanner/Models/Prompt.swift
@@ -1,0 +1,31 @@
+//
+//  Prompt.swift
+//  SoraPlanner
+//
+//  Created by Claude Code
+//
+
+import Foundation
+
+/// A reusable video generation prompt with metadata
+struct Prompt: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var text: String
+    var createdAt: Date
+    var modifiedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        title: String = "Untitled Prompt",
+        text: String = "",
+        createdAt: Date = Date(),
+        modifiedAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.text = text
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+    }
+}

--- a/SoraPlanner/ViewModels/PromptLibraryViewModel.swift
+++ b/SoraPlanner/ViewModels/PromptLibraryViewModel.swift
@@ -1,0 +1,96 @@
+//
+//  PromptLibraryViewModel.swift
+//  SoraPlanner
+//
+//  ViewModel for managing the prompt library with persistent storage
+//
+
+import Foundation
+import Combine
+import os
+
+@MainActor
+class PromptLibraryViewModel: ObservableObject {
+    // MARK: - Published Properties
+    @Published var prompts: [Prompt] = []
+    @Published var errorMessage: String?
+
+    // MARK: - Private Properties
+    private let userDefaultsKey = "saved_prompts"
+    private let logger = SoraPlannerLoggers.ui
+
+    // MARK: - Initialization
+    init() {
+        logger.info("PromptLibraryViewModel initialized")
+        loadPrompts()
+    }
+
+    // MARK: - Public Methods
+
+    /// Add a new empty prompt to the library
+    func addPrompt() {
+        logger.info("Adding new prompt")
+        let newPrompt = Prompt()
+        prompts.insert(newPrompt, at: 0) // Add at the top
+        savePrompts()
+    }
+
+    /// Update an existing prompt
+    func updatePrompt(_ prompt: Prompt) {
+        logger.debug("Updating prompt: \(prompt.id)")
+        if let index = prompts.firstIndex(where: { $0.id == prompt.id }) {
+            var updatedPrompt = prompt
+            updatedPrompt.modifiedAt = Date()
+            prompts[index] = updatedPrompt
+            savePrompts()
+        } else {
+            logger.warning("Attempted to update non-existent prompt: \(prompt.id)")
+        }
+    }
+
+    /// Delete a prompt from the library
+    func deletePrompt(_ prompt: Prompt) {
+        logger.info("Deleting prompt: \(prompt.id)")
+        prompts.removeAll { $0.id == prompt.id }
+        savePrompts()
+    }
+
+    /// Get a prompt by ID
+    func getPrompt(byId id: UUID) -> Prompt? {
+        return prompts.first { $0.id == id }
+    }
+
+    // MARK: - Private Methods
+
+    /// Load prompts from UserDefaults
+    private func loadPrompts() {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey) else {
+            logger.info("No saved prompts found")
+            prompts = []
+            return
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode([Prompt].self, from: data)
+            prompts = decoded.sorted { $0.createdAt > $1.createdAt } // Sort by newest first
+            logger.info("Loaded \(self.prompts.count) prompts from storage")
+        } catch {
+            logger.error("Failed to load prompts: \(error.localizedDescription)")
+            errorMessage = "Failed to load saved prompts: \(error.localizedDescription)"
+            prompts = []
+        }
+    }
+
+    /// Save prompts to UserDefaults
+    private func savePrompts() {
+        do {
+            let data = try JSONEncoder().encode(prompts)
+            UserDefaults.standard.set(data, forKey: userDefaultsKey)
+            logger.debug("Saved \(self.prompts.count) prompts to storage")
+            errorMessage = nil
+        } catch {
+            logger.error("Failed to save prompts: \(error.localizedDescription)")
+            errorMessage = "Failed to save prompts: \(error.localizedDescription)"
+        }
+    }
+}

--- a/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
+++ b/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
@@ -28,8 +28,15 @@ class VideoGenerationViewModel: ObservableObject {
     }
 
     // MARK: - Initialization
-    init() {
+    init(initialPrompt: String? = nil) {
         SoraPlannerLoggers.ui.info("VideoGenerationViewModel initialized")
+
+        // Set initial prompt if provided
+        if let prompt = initialPrompt, !prompt.isEmpty {
+            self.prompt = prompt
+            SoraPlannerLoggers.ui.debug("Initial prompt set: \(prompt.prefix(50))...")
+        }
+
         do {
             self.apiService = try VideoAPIService()
         } catch {

--- a/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
+++ b/SoraPlanner/ViewModels/VideoGenerationViewModel.swift
@@ -59,10 +59,11 @@ class VideoGenerationViewModel: ObservableObject {
     }
 
     /// Start video generation process
-    func generateVideo() async {
+    /// Returns true if generation was successful, false otherwise
+    func generateVideo() async -> Bool {
         guard canGenerate else {
             SoraPlannerLoggers.ui.warning("Cannot generate: invalid state")
-            return
+            return false
         }
 
         SoraPlannerLoggers.ui.info("Starting video generation")
@@ -81,22 +82,19 @@ class VideoGenerationViewModel: ObservableObject {
 
             SoraPlannerLoggers.ui.info("Video job created: \(job.id)")
 
-            // Show success message
-            successMessage = "Video queued! Check the Library tab for status."
-
-            // Reset form after brief delay
-            try await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 seconds
-
             // Reset the form
             prompt = ""
             duration = 4
             successMessage = nil
             isGenerating = false
 
+            return true
+
         } catch {
             SoraPlannerLoggers.ui.error("Failed to create video job: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
             isGenerating = false
+            return false
         }
     }
 

--- a/SoraPlanner/Views/PromptLibraryView.swift
+++ b/SoraPlanner/Views/PromptLibraryView.swift
@@ -1,0 +1,232 @@
+//
+//  PromptLibraryView.swift
+//  SoraPlanner
+//
+//  View for managing the prompt library with persistent storage
+//
+
+import SwiftUI
+
+struct PromptLibraryView: View {
+    @StateObject private var viewModel = PromptLibraryViewModel()
+    let onGeneratePrompt: (String) -> Void
+    let onGenerateEmpty: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Prompt Library")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+
+                Spacer()
+
+                // Generate with Empty Prompt Button
+                Button(action: {
+                    onGenerateEmpty()
+                }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "wand.and.stars")
+                        Text("Generate")
+                    }
+                }
+                .help("Create new video with empty prompt")
+
+                // Add New Prompt Button
+                Button(action: {
+                    viewModel.addPrompt()
+                }) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.title2)
+                }
+                .help("Add new prompt")
+            }
+            .padding()
+
+            Divider()
+
+            // Content
+            if let errorMessage = viewModel.errorMessage {
+                VStack(spacing: 16) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 48))
+                        .foregroundColor(.red)
+                    Text("Error Loading Prompts")
+                        .font(.headline)
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            } else if viewModel.prompts.isEmpty {
+                VStack(spacing: 16) {
+                    Image(systemName: "doc.text.fill")
+                        .font(.system(size: 48))
+                        .foregroundColor(.secondary)
+                    Text("No Prompts Yet")
+                        .font(.headline)
+                    Text("Create your first prompt to get started")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Button("Add Prompt") {
+                        viewModel.addPrompt()
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            } else {
+                // Prompt List
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(viewModel.prompts) { prompt in
+                            PromptRow(
+                                prompt: prompt,
+                                viewModel: viewModel,
+                                onGenerate: {
+                                    onGeneratePrompt(prompt.text)
+                                }
+                            )
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .frame(minWidth: 600, minHeight: 700)
+    }
+}
+
+struct PromptRow: View {
+    let prompt: Prompt
+    @ObservedObject var viewModel: PromptLibraryViewModel
+    let onGenerate: () -> Void
+
+    @State private var editedPrompt: Prompt
+    @State private var showDeleteConfirmation = false
+
+    // Character limit constant
+    private let maxCharacters = 2000
+
+    init(prompt: Prompt, viewModel: PromptLibraryViewModel, onGenerate: @escaping () -> Void) {
+        self.prompt = prompt
+        self.viewModel = viewModel
+        self.onGenerate = onGenerate
+        self._editedPrompt = State(initialValue: prompt)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Title Field
+            HStack {
+                TextField("Prompt Title", text: $editedPrompt.title)
+                    .textFieldStyle(.plain)
+                    .font(.headline)
+                    .onChange(of: editedPrompt.title) { oldValue, newValue in
+                        viewModel.updatePrompt(editedPrompt)
+                    }
+
+                Spacer()
+
+                // Delete Button
+                Button(action: {
+                    showDeleteConfirmation = true
+                }) {
+                    Image(systemName: "trash")
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+                .help("Delete prompt")
+            }
+
+            // Prompt Text Area
+            VStack(alignment: .leading, spacing: 4) {
+                TextEditor(text: $editedPrompt.text)
+                    .font(.body)
+                    .frame(minHeight: 80, maxHeight: 120)
+                    .padding(8)
+                    .background(Color(NSColor.textBackgroundColor))
+                    .cornerRadius(6)
+                    .onChange(of: editedPrompt.text) { oldValue, newValue in
+                        // Enforce character limit
+                        if newValue.count > maxCharacters {
+                            editedPrompt.text = String(newValue.prefix(maxCharacters))
+                        }
+                        viewModel.updatePrompt(editedPrompt)
+                    }
+
+                // Character count
+                HStack {
+                    Spacer()
+                    Text("\(editedPrompt.text.count) / \(maxCharacters)")
+                        .font(.caption2)
+                        .foregroundColor(editedPrompt.text.count >= maxCharacters ? .red : .secondary)
+                }
+            }
+
+            // Action Buttons and Metadata
+            HStack {
+                // Generate Button
+                Button(action: {
+                    onGenerate()
+                }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "wand.and.stars")
+                        Text("Generate")
+                    }
+                    .font(.caption)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(editedPrompt.text.isEmpty)
+                .help(editedPrompt.text.isEmpty ? "Add text to generate video" : "Generate video with this prompt")
+
+                Spacer()
+
+                // Metadata
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("Created: \(formattedDate(editedPrompt.createdAt))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+
+                    if editedPrompt.modifiedAt != editedPrompt.createdAt {
+                        Text("Modified: \(formattedDate(editedPrompt.modifiedAt))")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .confirmationDialog(
+            "Delete Prompt?",
+            isPresented: $showDeleteConfirmation,
+            presenting: prompt
+        ) { prompt in
+            Button("Delete", role: .destructive) {
+                viewModel.deletePrompt(prompt)
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: { prompt in
+            Text("Are you sure you want to delete '\(prompt.title)'? This action cannot be undone.")
+        }
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+#Preview {
+    PromptLibraryView(
+        onGeneratePrompt: { _ in },
+        onGenerateEmpty: { }
+    )
+}

--- a/SoraPlanner/Views/PromptLibraryView.swift
+++ b/SoraPlanner/Views/PromptLibraryView.swift
@@ -87,7 +87,6 @@ struct PromptLibraryView: View {
                                 prompt: prompt,
                                 viewModel: viewModel,
                                 onGenerate: {
-                                    print("DEBUG: PromptRow Generate button tapped - prompt.text: '\(prompt.text)'")
                                     onGeneratePrompt(prompt.text)
                                 }
                             )

--- a/SoraPlanner/Views/PromptLibraryView.swift
+++ b/SoraPlanner/Views/PromptLibraryView.swift
@@ -87,6 +87,7 @@ struct PromptLibraryView: View {
                                 prompt: prompt,
                                 viewModel: viewModel,
                                 onGenerate: {
+                                    print("DEBUG: PromptRow Generate button tapped - prompt.text: '\(prompt.text)'")
                                     onGeneratePrompt(prompt.text)
                                 }
                             )

--- a/SoraPlanner/Views/VideoGenerationView.swift
+++ b/SoraPlanner/Views/VideoGenerationView.swift
@@ -9,12 +9,17 @@ import SwiftUI
 import AVKit
 
 struct VideoGenerationView: View {
-    @StateObject private var viewModel = VideoGenerationViewModel()
+    @StateObject private var viewModel: VideoGenerationViewModel
     @EnvironmentObject var playerCoordinator: VideoPlayerCoordinator
     @Environment(\.dismiss) private var dismiss
 
-    let initialPrompt: String?
     let onGenerationSuccess: () -> Void
+
+    init(initialPrompt: String?, onGenerationSuccess: @escaping () -> Void) {
+        self.onGenerationSuccess = onGenerationSuccess
+        // Create the view model with the initial prompt
+        self._viewModel = StateObject(wrappedValue: VideoGenerationViewModel(initialPrompt: initialPrompt))
+    }
 
     var body: some View {
         VStack(spacing: 20) {
@@ -150,14 +155,6 @@ struct VideoGenerationView: View {
         }
         .frame(minWidth: 600, minHeight: 700)
         .onAppear {
-            print("DEBUG: VideoGenerationView.onAppear - initialPrompt: '\(initialPrompt ?? "nil")'")
-            // Set initial prompt if provided
-            if let prompt = initialPrompt, !prompt.isEmpty {
-                print("DEBUG: Setting viewModel.prompt to: '\(prompt)'")
-                viewModel.prompt = prompt
-            } else {
-                print("DEBUG: Not setting prompt - initialPrompt is nil or empty")
-            }
             // Retry API service initialization in case user just added API key in Settings
             viewModel.retryAPIServiceInitialization()
         }

--- a/SoraPlanner/Views/VideoGenerationView.swift
+++ b/SoraPlanner/Views/VideoGenerationView.swift
@@ -11,6 +11,9 @@ import AVKit
 struct VideoGenerationView: View {
     @StateObject private var viewModel = VideoGenerationViewModel()
     @EnvironmentObject var playerCoordinator: VideoPlayerCoordinator
+    @Environment(\.dismiss) private var dismiss
+
+    let initialPrompt: String?
 
     var body: some View {
         VStack(spacing: 20) {
@@ -131,13 +134,27 @@ struct VideoGenerationView: View {
         }
         .frame(minWidth: 600, minHeight: 700)
         .onAppear {
+            // Set initial prompt if provided
+            if let prompt = initialPrompt {
+                viewModel.prompt = prompt
+            }
             // Retry API service initialization in case user just added API key in Settings
             viewModel.retryAPIServiceInitialization()
+        }
+        .onChange(of: viewModel.successMessage) { oldValue, newValue in
+            // Dismiss modal after successful generation
+            if newValue != nil {
+                Task {
+                    // Wait for success message to be shown
+                    try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+                    dismiss()
+                }
+            }
         }
     }
 }
 
 #Preview {
-    VideoGenerationView()
+    VideoGenerationView(initialPrompt: nil)
         .environmentObject(VideoPlayerCoordinator())
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue #13 - adds a comprehensive prompt library management system with persistent storage and modal video generation workflow.

### Key Features

✅ **Prompts Tab**
- Replaces the existing Generate tab with a dedicated Prompts library
- Persistent storage using UserDefaults (survives app restarts)
- Inline editing of prompt titles and text
- Character limit enforcement (2000 characters) with visual feedback
- Empty state UI for new users

✅ **Modal Generation Workflow**
- Video generation now opens in a modal sheet
- Can be launched with pre-filled prompt from library
- Can be launched empty via toolbar button
- Auto-dismisses after successful generation

✅ **CRUD Operations**
- Add new prompts via toolbar button
- Edit titles and text inline with auto-save
- Delete prompts with confirmation dialog
- Created and modified timestamps

### Technical Implementation

**New Files:**
- `SoraPlanner/Models/Prompt.swift` - Data model (UUID, title, text, timestamps)
- `SoraPlanner/ViewModels/PromptLibraryViewModel.swift` - Business logic with UserDefaults persistence
- `SoraPlanner/Views/PromptLibraryView.swift` - UI with LazyVStack and inline editing

**Modified Files:**
- `ContentView.swift` - Tab structure updated, modal sheet added
- `VideoGenerationView.swift` - Accepts optional initialPrompt, auto-dismisses on success
- `CLAUDE.md` - Comprehensive documentation updates

### Architecture

- Follows established MVVM pattern
- Uses @MainActor isolation for thread safety
- Implements auto-save on all modifications
- Uses existing UI patterns from VideoLibraryView
- Proper error handling and logging

### Testing

✅ Build successful - no compilation errors or warnings
✅ Follows project coding standards
✅ Documentation fully updated

## Closes

Closes #13

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)