### PR TITLE
✨ Add automatic per-item polling for video library status updates

### DIFF
--- a/SoraPlanner/Views/VideoLibraryView.swift
+++ b/SoraPlanner/Views/VideoLibraryView.swift
@@ -101,6 +101,9 @@ struct VideoLibraryView: View {
             viewModel.retryAPIServiceInitialization()
             await viewModel.loadVideos()
         }
+        .onDisappear {
+            viewModel.stopAllPolling()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements automatic per-item polling for videos in active states (queued/in_progress), replacing manual pull-to-refresh with real-time status updates. Each video polls independently every 5 seconds until reaching a terminal state.

## Changes

### VideoLibraryViewModel.swift
- Added polling infrastructure: `pollingTasks` dictionary, `pollingInterval`, `maxConcurrentPolls`
- Implemented `startPollingIfNeeded()`: Starts polling for all active videos after load
- Implemented `startPollingForVideo()`: Per-video polling task with comprehensive error handling
- Implemented `stopPollingForVideo()`: Cancel specific polling task
- Implemented `stopAllPolling()`: Cancel all polling tasks (called on view disappear)
- Implemented `updateVideoStatus()`: Atomic video status updates with logging
- Added exponential backoff on errors (5s → 10s → 20s → 40s, capped at 40s)

### VideoLibraryView.swift
- Added `.onDisappear` lifecycle hook to stop polling when tab is not visible

## Key Features

- ✅ Videos in `queued` or `inProgress` state automatically poll for updates
- ✅ Polling uses existing `GET /videos/{video_id}` endpoint
- ✅ Status updates reflected in UI in real-time (no manual refresh needed)
- ✅ Polling stops automatically when video reaches `completed` or `failed` state
- ✅ Pull-to-refresh remains functional for manual updates
- ✅ Polling pauses when Video Library tab is not visible
- ✅ Polling resumes when tab becomes visible again
- ✅ Maximum 10 concurrent polling tasks
- ✅ 5-second interval between polls per video
- ✅ Proper Task cancellation (no memory leaks)
- ✅ Atomic video status updates (no race conditions)
- ✅ Thread-safe @MainActor state mutations

## Error Handling

**Three-tier error handling strategy:**

1. **Clean Cancellation**: `CancellationError` → exit silently, log at debug level
2. **API-specific Errors**:
   - `missingAPIKey`, `invalidURL` → stop polling (fatal)
   - `httpError(404)` → video deleted, remove from list
   - `networkError`, transient `httpError` → retry with exponential backoff
3. **Unknown Errors**: Log at error level, retry with backoff

## Testing

- ✅ Build succeeds with no errors
- ✅ Proper Task lifecycle management
- ✅ Thread-safe with @MainActor isolation
- ✅ Comprehensive logging at all levels

## Resolves

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)