### PR TITLE
🔴 Fix critical service initialization anti-pattern with dependency injection

### DIFF
--- a/SoraPlanner/AppDependencies.swift
+++ b/SoraPlanner/AppDependencies.swift
@@ -1,0 +1,39 @@
+//
+//  AppDependencies.swift
+//  SoraPlanner
+//
+//  Centralized dependency container for app-level services
+//
+
+import SwiftUI
+import Combine
+import os
+
+@MainActor
+class AppDependencies: ObservableObject {
+    @Published private(set) var apiService: VideoAPIService?
+    @Published private(set) var initializationError: String?
+    @Published private(set) var isInitialized: Bool = false
+
+    init() {
+        initializeService()
+    }
+
+    func initializeService() {
+        do {
+            apiService = try VideoAPIService()
+            initializationError = nil
+            isInitialized = true
+            SoraPlannerLoggers.api.info("API service initialized successfully")
+        } catch {
+            apiService = nil
+            initializationError = error.localizedDescription
+            isInitialized = false
+            SoraPlannerLoggers.api.error("Failed to initialize API service: \(error)")
+        }
+    }
+
+    func reinitialize() {
+        initializeService()
+    }
+}

--- a/SoraPlanner/ContentView.swift
+++ b/SoraPlanner/ContentView.swift
@@ -14,9 +14,15 @@ struct VideoGenerationRequest: Identifiable {
 }
 
 struct ContentView: View {
-    @StateObject private var playerCoordinator = VideoPlayerCoordinator()
+    let apiService: VideoAPIService
+    @StateObject private var playerCoordinator: VideoPlayerCoordinator
     @State private var generationRequest: VideoGenerationRequest?
     @State private var showGenerationSuccess = false
+
+    init(apiService: VideoAPIService) {
+        self.apiService = apiService
+        self._playerCoordinator = StateObject(wrappedValue: VideoPlayerCoordinator(service: apiService))
+    }
 
     var body: some View {
         TabView {
@@ -32,7 +38,7 @@ struct ContentView: View {
                 Label("Prompts", systemImage: "doc.text.fill")
             }
 
-            VideoLibraryView()
+            VideoLibraryView(apiService: apiService)
                 .tabItem {
                     Label("Library", systemImage: "video.stack")
                 }
@@ -50,6 +56,7 @@ struct ContentView: View {
         }
         .sheet(item: $generationRequest) { request in
             VideoGenerationView(
+                apiService: apiService,
                 initialPrompt: request.initialPrompt,
                 onGenerationSuccess: {
                     showGenerationSuccess = true
@@ -65,6 +72,7 @@ struct ContentView: View {
     }
 }
 
-#Preview {
-    ContentView()
-}
+// Preview disabled - requires valid API service
+// #Preview {
+//     ContentView(apiService: <#VideoAPIService#>)
+// }

--- a/SoraPlanner/SoraPlannerApp.swift
+++ b/SoraPlanner/SoraPlannerApp.swift
@@ -9,9 +9,19 @@ import SwiftUI
 
 @main
 struct SoraPlannerApp: App {
+    @StateObject private var dependencies = AppDependencies()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if dependencies.isInitialized, let apiService = dependencies.apiService {
+                ContentView(apiService: apiService)
+                    .environmentObject(dependencies)
+            } else {
+                InitializationErrorView(
+                    error: dependencies.initializationError,
+                    onRetry: { dependencies.reinitialize() }
+                )
+            }
         }
     }
 }

--- a/SoraPlanner/ViewModels/VideoPlayerCoordinator.swift
+++ b/SoraPlanner/ViewModels/VideoPlayerCoordinator.swift
@@ -19,17 +19,12 @@ class VideoPlayerCoordinator: ObservableObject {
     @Published var errorMessage: String?
 
     // MARK: - Private Properties
-    private var apiService: VideoAPIService?
+    private let service: VideoAPIService
 
     // MARK: - Initialization
-    init() {
+    init(service: VideoAPIService) {
+        self.service = service
         SoraPlannerLoggers.ui.info("VideoPlayerCoordinator initialized")
-        do {
-            self.apiService = try VideoAPIService()
-        } catch {
-            SoraPlannerLoggers.ui.error("Failed to initialize API service: \(error.localizedDescription)")
-            self.errorMessage = error.localizedDescription
-        }
     }
 
     // MARK: - Public Methods
@@ -52,10 +47,6 @@ class VideoPlayerCoordinator: ObservableObject {
         }
 
         do {
-            guard let service = apiService else {
-                throw VideoAPIError.missingAPIKey
-            }
-
             // Download video content
             SoraPlannerLoggers.video.info("Downloading video: \(video.id)")
             let localURL = try await service.downloadVideo(videoId: video.id)

--- a/SoraPlanner/Views/InitializationErrorView.swift
+++ b/SoraPlanner/Views/InitializationErrorView.swift
@@ -1,0 +1,58 @@
+//
+//  InitializationErrorView.swift
+//  SoraPlanner
+//
+//  View displayed when app fails to initialize API service
+//
+
+import SwiftUI
+
+struct InitializationErrorView: View {
+    let error: String?
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 64))
+                .foregroundColor(.red)
+
+            Text("Initialization Failed")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+
+            if let error = error {
+                Text(error)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            Button(action: onRetry) {
+                HStack {
+                    Image(systemName: "arrow.clockwise")
+                    Text("Retry")
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Text("Tip: Make sure you've added your OpenAI API key in the Settings tab")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+#Preview {
+    InitializationErrorView(
+        error: "No API key configured. Please add your OpenAI API key in the Settings tab.",
+        onRetry: {}
+    )
+}

--- a/SoraPlanner/Views/VideoGenerationView.swift
+++ b/SoraPlanner/Views/VideoGenerationView.swift
@@ -16,10 +16,10 @@ struct VideoGenerationView: View {
 
     let onGenerationSuccess: () -> Void
 
-    init(initialPrompt: String?, onGenerationSuccess: @escaping () -> Void) {
+    init(apiService: VideoAPIService, initialPrompt: String?, onGenerationSuccess: @escaping () -> Void) {
         self.onGenerationSuccess = onGenerationSuccess
-        // Create the view model with the initial prompt
-        self._viewModel = StateObject(wrappedValue: VideoGenerationViewModel(initialPrompt: initialPrompt))
+        // Create the view model with the injected service and initial prompt
+        self._viewModel = StateObject(wrappedValue: VideoGenerationViewModel(service: apiService, initialPrompt: initialPrompt))
     }
 
     var body: some View {
@@ -234,14 +234,11 @@ struct VideoGenerationView: View {
             Spacer()
         }
         .frame(minWidth: 600, minHeight: 600)
-        .onAppear {
-            // Retry API service initialization in case user just added API key in Settings
-            viewModel.retryAPIServiceInitialization()
-        }
     }
 }
 
-#Preview {
-    VideoGenerationView(initialPrompt: nil, onGenerationSuccess: {})
-        .environmentObject(VideoPlayerCoordinator())
-}
+// Preview disabled - requires valid API service
+// #Preview {
+//     VideoGenerationView(apiService: <#VideoAPIService#>, initialPrompt: nil, onGenerationSuccess: {})
+//         .environmentObject(VideoPlayerCoordinator(service: <#VideoAPIService#>))
+// }

--- a/SoraPlanner/Views/VideoLibraryView.swift
+++ b/SoraPlanner/Views/VideoLibraryView.swift
@@ -8,8 +8,12 @@
 import SwiftUI
 
 struct VideoLibraryView: View {
-    @StateObject private var viewModel = VideoLibraryViewModel()
+    @StateObject private var viewModel: VideoLibraryViewModel
     @EnvironmentObject var playerCoordinator: VideoPlayerCoordinator
+
+    init(apiService: VideoAPIService) {
+        self._viewModel = StateObject(wrappedValue: VideoLibraryViewModel(service: apiService))
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -97,8 +101,6 @@ struct VideoLibraryView: View {
         }
         .frame(minWidth: 600, minHeight: 700)
         .task {
-            // Retry API service initialization in case user just added API key in Settings
-            viewModel.retryAPIServiceInitialization()
             await viewModel.loadVideos()
         }
         .onDisappear {
@@ -301,7 +303,8 @@ struct VideoLibraryRow: View {
     }
 }
 
-#Preview {
-    VideoLibraryView()
-        .environmentObject(VideoPlayerCoordinator())
-}
+// Preview disabled - requires valid API service
+// #Preview {
+//     VideoLibraryView(apiService: <#VideoAPIService#>)
+//         .environmentObject(VideoPlayerCoordinator(service: <#VideoAPIService#>))
+// }


### PR DESCRIPTION
## Summary

Implements centralized dependency injection for `VideoAPIService` to eliminate the critical anti-pattern of ViewModels creating their own service instances. This refactoring addresses fundamental architectural issues identified in #17.

## Changes Made

### New Files
- ✨ `AppDependencies.swift` - Centralized dependency container with single source of truth for API service
- ✨ `InitializationErrorView.swift` - Dedicated error view for app-level initialization failures

### Refactored Components

**ViewModels** (all now accept injected service):
- `VideoGenerationViewModel` - Removed try/catch init, accepts service parameter
- `VideoLibraryViewModel` - Removed try/catch init, accepts service parameter  
- `VideoPlayerCoordinator` - Removed try/catch init, accepts service parameter

**Views** (all updated to pass injected service):
- `SoraPlannerApp` - Now manages `AppDependencies` and shows error view on failure
- `ContentView` - Accepts `apiService` and passes to child views
- `VideoGenerationView` - Accepts `apiService` parameter
- `VideoLibraryView` - Accepts `apiService` parameter

**Removed Code**:
- ❌ All `retryAPIServiceInitialization()` methods across ViewModels
- ❌ All `onAppear` retry logic in views
- ❌ SwiftUI previews (disabled - require valid API service for prototyping)

## Benefits

✅ **Single source of truth** - One `VideoAPIService` instance shared across app  
✅ **Centralized error handling** - Failures handled at app level, not per-ViewModel  
✅ **Testability** - Easy to inject mock services for unit testing (future work)  
✅ **Clear initialization contract** - ViewModels can't exist in broken state  
✅ **Eliminates state fragmentation** - No more inconsistent states across ViewModels  
✅ **Reduces code duplication** - No more retry mechanisms in every ViewModel

## Testing

- ✅ Project builds successfully with no compilation errors
- ✅ All ViewModels properly initialized with injected service
- ✅ Error view displays when API key is missing
- ✅ App functions correctly with valid API key

## References

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)