### PR TITLE
🔴 Fix critical MainActor service layer anti-pattern

### DIFF
--- a/SoraPlanner/Services/VideoAPIService.swift
+++ b/SoraPlanner/Services/VideoAPIService.swift
@@ -34,7 +34,6 @@ enum VideoAPIError: LocalizedError {
     }
 }
 
-@MainActor
 class VideoAPIService {
     private let baseURL = "https://api.openai.com/v1/videos"
     private let apiKey: String


### PR DESCRIPTION
## Summary

Fixes #18 - Removes `@MainActor` annotation from `VideoAPIService` to resolve critical architectural violation.

### Problem
`VideoAPIService` was incorrectly marked with `@MainActor`, forcing all network operations to run on the main thread. This caused:
- UI jank and performance degradation
- Violation of separation of concerns
- Unnecessary thread hopping

### Solution
- Removed `@MainActor` from `VideoAPIService` class
- Network operations now run on background threads (URLSession handles threading automatically)
- ViewModels remain properly `@MainActor`-isolated for UI updates

### Changes
- **Modified:** `SoraPlanner/Services/VideoAPIService.swift`
  - Removed `@MainActor` annotation (line 37)

### Verification
✅ All ViewModels verified to be `@MainActor`-isolated:
  - VideoGenerationViewModel
  - VideoLibraryViewModel
  - VideoPlayerCoordinator

✅ Project builds successfully with no compilation errors
✅ Proper architectural separation maintained

### Benefits
- Network operations run on background threads
- No UI blocking or jank
- Better performance
- Follows Swift concurrency best practices

## Test Plan
- [x] Build project successfully
- [x] Verify ViewModels are MainActor-isolated
- [x] Confirm service methods work without MainActor
- [ ] Test video generation flow
- [ ] Test video library loading
- [ ] Verify UI remains responsive during network operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)